### PR TITLE
add RuntimeIdentifier

### DIFF
--- a/DivaModManager/DivaModManager.csproj
+++ b/DivaModManager/DivaModManager.csproj
@@ -8,6 +8,7 @@
     <ApplicationIcon>Assets\miku.ico</ApplicationIcon>
     <AssemblyName>DivaModManager</AssemblyName>
     <AssemblyVersion>1.0.1.0</AssemblyVersion>
+    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
apparently this is necessary to run `-r win10-x64` on a CI when publishing, so i'm upstreaming it in case you wanna do a github workflow at some point