### PR TITLE
Use SevenZipExtractor for extracting 7z archives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ bld/
 
 # Visual Studio 2015/2017 cache/options directory
 .vs/
+# JetBrains Rider
+.idea/
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 

--- a/DivaModManager/DivaModManager.csproj
+++ b/DivaModManager/DivaModManager.csproj
@@ -7,7 +7,7 @@
     <UseWPF>true</UseWPF>
     <ApplicationIcon>Assets\miku.ico</ApplicationIcon>
     <AssemblyName>DivaModManager</AssemblyName>
-    <AssemblyVersion>1.2.7.0</AssemblyVersion>
+    <AssemblyVersion>1.2.8.0</AssemblyVersion>
     <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
   </PropertyGroup>
 
@@ -34,6 +34,7 @@
     <PackageReference Include="gong-wpf-dragdrop" Version="3.1.1" />
     <PackageReference Include="Octokit" Version="0.51.0" />
     <PackageReference Include="Onova" Version="2.6.2" />
+    <PackageReference Include="SevenZipExtractor" Version="1.0.17" />
     <PackageReference Include="SharpCompress" Version="0.32.0" />
     <PackageReference Include="Tomlyn" Version="0.14.3" />
     <PackageReference Include="WpfAnimatedGif" Version="2.0.2" />

--- a/DivaModManager/ModDownloader.cs
+++ b/DivaModManager/ModDownloader.cs
@@ -11,6 +11,7 @@ using SharpCompress.Readers;
 using DivaModManager.UI;
 using SharpCompress.Archives.SevenZip;
 using System.Linq;
+using SevenZipExtractor;
 
 namespace DivaModManager
 {
@@ -173,18 +174,9 @@ namespace DivaModManager
                 {
                     if (Path.GetExtension(_ArchiveSource).Equals(".7z", StringComparison.InvariantCultureIgnoreCase))
                     {
-                        using (var archive = SevenZipArchive.Open(_ArchiveSource))
+                        using (var archive = new ArchiveFile(_ArchiveSource))
                         {
-                            var reader = archive.ExtractAllEntries();
-                            while (reader.MoveToNextEntry())
-                            {
-                                if (!reader.Entry.IsDirectory)
-                                    reader.WriteEntryToDirectory(ArchiveDestination, new ExtractionOptions() 
-                                    { 
-                                        ExtractFullPath = true, 
-                                        Overwrite = true 
-                                    });
-                            }
+                            archive.Extract(ArchiveDestination);
                         }
                     }
                     else

--- a/DivaModManager/ModUpdater.cs
+++ b/DivaModManager/ModUpdater.cs
@@ -7,12 +7,10 @@ using System.Text.Json;
 using System.Net.Http;
 using System.Threading;
 using DivaModManager.UI;
-using System.Reflection;
 using System.Windows;
+using SevenZipExtractor;
 using SharpCompress.Common;
 using SharpCompress.Readers;
-using SharpCompress.Archives.SevenZip;
-using SharpCompress.Archives;
 using Tomlyn;
 using Tomlyn.Model;
 
@@ -360,18 +358,9 @@ namespace DivaModManager
                 {
                     if (Path.GetExtension(_ArchiveSource).Equals(".7z", StringComparison.InvariantCultureIgnoreCase))
                     {
-                        using (var archive = SevenZipArchive.Open(_ArchiveSource))
+                        using (var archive = new ArchiveFile(_ArchiveSource))
                         {
-                            var reader = archive.ExtractAllEntries();
-                            while (reader.MoveToNextEntry())
-                            {
-                                if (!reader.Entry.IsDirectory)
-                                    reader.WriteEntryToDirectory(ArchiveDestination, new ExtractionOptions()
-                                    {
-                                        ExtractFullPath = true,
-                                        Overwrite = true
-                                    });
-                            }
+                            archive.Extract(ArchiveDestination);
                         }
                     }
                     else

--- a/DivaModManager/ZipExtractor.cs
+++ b/DivaModManager/ZipExtractor.cs
@@ -1,14 +1,10 @@
 ﻿using Onova.Services;
 using System;
-using System.Diagnostics;
 using System.IO;
-using System.Linq;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using SevenZipExtractor;
 using SharpCompress.Common;
-using SharpCompress.Archives;
-using SharpCompress.Archives.SevenZip;
 using SharpCompress.Readers;
 
 namespace DivaModManager
@@ -22,18 +18,9 @@ namespace DivaModManager
             {
                 if (Path.GetExtension(sourceFilePath).Equals(".7z", StringComparison.InvariantCultureIgnoreCase))
                 {
-                    using (var archive = SevenZipArchive.Open(sourceFilePath))
+                    using (var archive = new ArchiveFile(sourceFilePath))
                     {
-                        var reader = archive.ExtractAllEntries();
-                        while (reader.MoveToNextEntry())
-                        {
-                            if (!reader.Entry.IsDirectory)
-                                reader.WriteEntryToDirectory(destDirPath, new ExtractionOptions()
-                                {
-                                    ExtractFullPath = true,
-                                    Overwrite = true
-                                });
-                        }
+                        archive.Extract(destDirPath);
                     }
                 }
                 else


### PR DESCRIPTION
This fixes #28. SharpCompress [does not support](https://github.com/adamhathcock/sharpcompress/issues/526) extracting 7z archives that have been compressed with "Ultra Compression", which is what causes the error. The [SevenZipExtractor](https://www.nuget.org/packages/SevenZipExtractor) library does support extracting these archives.  

SharpCompress is still used for extracting non-7z archives.