### PR TITLE
Enable text search on `ModGrid`

### DIFF
--- a/DivaModManager/UI/MainWindow.xaml
+++ b/DivaModManager/UI/MainWindow.xaml
@@ -453,6 +453,7 @@
                           EnableColumnVirtualization="False" CanUserAddRows="False" CanUserDeleteRows="False" CanUserReorderColumns="False"
                           CanUserResizeColumns="False" CanUserResizeRows="False" CanUserSortColumns="False" AlternatingRowBackground="#2A2A2A"
                           dd:DragDrop.IsDragSource="True" dd:DragDrop.IsDropTarget="True" HeadersVisibility="Column" 
+                          IsTextSearchEnabled="True" TextSearch.TextPath="name"
                           SelectionMode="Extended" RowBackground="#202020" Foreground="#f2f2f2" LoadingRow="ModGrid_LoadingRow" HorizontalScrollBarVisibility="Hidden"
                           HorizontalAlignment="Center" Background="#202020" Grid.Column="0" FontSize="15" PreviewKeyDown="ModGrid_PreviewKeyDown"
                           ContextMenuOpening="ModGrid_ContextMenuOpening" SelectionChanged="ModGrid_SelectionChanged"  FontFamily="{StaticResource AnekLatin}">


### PR DESCRIPTION
This PR enables text search on the mod list, which means that if you have a lot of mods like I do, you can just start typing a name and it will select a matching mod from the list. Literally just added one line to MainWindow's XAML.